### PR TITLE
changed logic for hasClass function

### DIFF
--- a/showup.js
+++ b/showup.js
@@ -111,7 +111,9 @@
    * @return-{boolean}
    */
   var hasClass = function (className) {
-    return this.className.indexOf(className) > -1;
+    var regex = new RegExp('(^| )' + className + '($| )');
+    
+    return regex.test(this.className);
   };
 
 


### PR DESCRIPTION
It obviously wouldn't happen here, but using `indexOf` can sometimes lead to weird results.. like if you were checking for a class of `'hi'` inside of `'hi-diddly-ho'`.

D:
